### PR TITLE
Improvements about sources loading

### DIFF
--- a/lib/sources.js
+++ b/lib/sources.js
@@ -18,6 +18,7 @@ const sourceByRefProtocol = 'sourceref:';
 function Sources() {
   this._variables = {};
   this._sources = {};
+  this._sourcesIds = [];
 
   // Set up a ref protocol resolver - this way its enough to specify the source
   // by sourceref:///?ref=sourceID URL, instead of a full source URL.
@@ -72,8 +73,12 @@ Sources.prototype.init = function init(conf) {
     }
     _.each(conf.modules, core.registerTileliveModule);
     self.loadVariablesAsync(self._localOrExternalDataAsync(conf.variables, 'variables'));
-  }).then(() =>
-    self.loadSourcesAsync(self._localOrExternalDataAsync(conf.sources, 'sources'))).return(self);
+  })
+    .then(() => self._localOrExternalDataAsync(conf.sources, 'sources'))
+    .then((sourcesConf) => {
+      self._sourcesIds = Object.keys(sourcesConf);
+      return self.loadSourcesAsync(sourcesConf);
+    }).return(self);
 };
 
 /**
@@ -98,8 +103,13 @@ Sources.prototype.loadSourcesAsync = function loadSourcesAsync(sources) {
     if (!_.isObject(sources) || _.isArray(sources)) {
       throw new Err('Sources must be an object');
     }
-    return Promise.each(
+    const sortedSourcesIds = _.sortBy(
+      // Sort sources keys respecting dependency order
       Object.keys(sources),
+      id => _.indexOf(self._sourcesIds, id)
+    );
+    return Promise.each(
+      sortedSourcesIds,
       key => self._loadSourceAsync(sources[key], key)
     );
   });
@@ -264,6 +274,9 @@ Sources.prototype._loadSourceAsync = function _loadSourceAsync(src, sourceId) {
 
     // eslint-disable-next-line no-param-reassign
     src.getHandler = () => handler;
+
+    // eslint-disable-next-line no-param-reassign
+    src.isDisabled = false;
   })
     .catch((err) => {
       // eslint-disable-next-line no-param-reassign


### PR DESCRIPTION
* sources ids are stored (in dependency order) on initialization
* use this dependency order when loading multiple sources in `loadSourcesAsync`
* `isDisabled` flag is reset to false when reloading a source